### PR TITLE
remove dependency on asynctest for python >=3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,8 @@ classifier =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [files]
 packages =

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,4 +12,4 @@ pytest-sugar>=0.8.0
 pytest-asyncio>=0.5.0
 
 # unittest
-asynctest>=0.10.0
+asynctest>=0.10.0; python_version < '3.8'

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,7 +2,13 @@ from io import BufferedReader
 
 import aiofiles
 from aiofiles import base, threadpool
-from asynctest import mock
+import sys
+if sys.version < "3.8":
+   # asynctest only supports older pythons
+   from asynctest import mock
+else:
+   # Python 3.8 and later can mock.patch async functions
+   from unittest import mock
 from pyfakefs import fake_filesystem
 import pytest
 


### PR DESCRIPTION
Hi,

if you ever consider updating this package to support newer pythons, here is how.

*This came up, because pytest-aiofiles is in openSUSE Tumbleweed and we removed asynctest for Python 3.8. So pytest-aiofiles did not build anymore*
